### PR TITLE
Close splits automatically

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,18 +10,18 @@ Lets be honest, a window in Vim is not equivalent to a tab in say TextMate - the
 
 Here's how I want ⌘W to work:
 
-- Close the current buffer but keep the window open (which [buffkill](http://www.vim.org/scripts/script.php?script_id=1147) already solves with it's `:BD` command).
+- Close the current buffer but keep the window open (which [vim-bbye][1] already solves with it's `:Bd` command).
 - When I press ⌘W on the last **listed**\* buffer, I want MacVim to close.
 
 \*A listed buffer is one that shows up when you type the `:buffers` command. Usually this list only includes editable buffers, so read-only buffers like NERDTree won't show up in this list.
 
 ## Requirements
 * Vim 7+
-* [buffkill](http://www.vim.org/scripts/script.php?script_id=1147) - Allows you to close a buffer without closing a window.
+* [vim-bbye][1] - Allows you to close a buffer without closing a window.
 
 ## Installation
 
-First, make sure you have [buffkill](http://www.vim.org/scripts/script.php?script_id=1147) installed. Command-W will not function correctly without it.
+First, make sure you have [vim-bbye][1] installed. Command-W will not function correctly without it.
 
 ### Manual
 Simply copy the `plugin` directory into your `.vim` directory.
@@ -51,4 +51,6 @@ Add the following to your `.gvimrc`:
 Now you can press ⌘W to close buffers (or to close Vim if you've only got one buffer open).
 
 ### Other
-You can manually use `:CommandW` instead of `:bd` (or `:BD` if you use bufkill).
+You can manually use `:CommandW` instead of `:bd` (or `:Bd` if you use bbye).
+
+[1]: https://github.com/moll/vim-bbye

--- a/plugin/command-w.vim
+++ b/plugin/command-w.vim
@@ -21,6 +21,23 @@ function! s:CommandW()
   else
     if exists('g:loaded_bufkill')
       BD
+
+      " Close window if it has a buffer open that is open in another window
+      let l:curbuf = bufnr('%')
+      let l:wincount = 0
+      let i = 1
+      let buf = winbufnr(i)
+      while buf != -1
+        if buf == l:curbuf
+          let l:wincount += 1
+        endif
+        let i = i + 1
+        let buf = winbufnr(i)
+      endwhile
+
+      if l:wincount > 1
+        quit
+      endif
     else
       call s:BufkillError()
       q

--- a/plugin/command-w.vim
+++ b/plugin/command-w.vim
@@ -6,10 +6,10 @@ if exists('g:loaded_command_w') || &cp
 endif
 let g:loaded_command_w = 1
 
-function s:BufkillError()
-  if !exists('g:command_w_bufkill_error_shown')
-    echoe 'Command-W requires the bufkill plugin to be installed in order to operate correctly'
-    let g:command_w_bufkill_error_shown = 1
+function s:BByeError()
+  if !exists('g:command_w_bbye_error_shown')
+    echoe 'Command-W requires the bbye plugin to be installed in order to operate correctly'
+    let g:command_w_bbye_error_shown = 1
   endif
 endfunction
 
@@ -19,8 +19,8 @@ function! s:CommandW()
   if l:bufcount == 1
     qall
   else
-    if exists('g:loaded_bufkill')
-      BD
+    if exists('g:loaded_bbye')
+      Bdelete
 
       " Close window if it has a buffer open that is open in another window
       let l:curbuf = bufnr('%')
@@ -39,7 +39,7 @@ function! s:CommandW()
         quit
       endif
     else
-      call s:BufkillError()
+      call s:BByeError()
       q
     endif
   endif


### PR DESCRIPTION
I"m not sure if this is the best way to do this, but this will detect that a buffer loaded in a window after a `:CommandW` is in another window elsewhere. If it is, it will close the split.
